### PR TITLE
Fix excessive N requests for changing order of topics

### DIFF
--- a/app/controllers/api/v1/topics_controller.rb
+++ b/app/controllers/api/v1/topics_controller.rb
@@ -3,7 +3,7 @@ module Api
     class TopicsController < Api::V1::BaseController
       respond_to :json
 
-      TOPIC_PARAMS = %i[title description order_index]
+      TOPIC_PARAMS = %i[title description order_index].freeze
 
       expose :topic
       expose :course
@@ -13,6 +13,8 @@ module Api
       end
 
       def update
+        Teachers::Topics::UpdateOrderIndexes.call(topic: topic, new_index: topic_params["order_index"].to_i)
+
         topic.update_attributes(topic_params)
         topic.save
 

--- a/app/interactors/teachers/topics/update_order_indexes.rb
+++ b/app/interactors/teachers/topics/update_order_indexes.rb
@@ -1,0 +1,47 @@
+module Teachers
+  module Topics
+    class UpdateOrderIndexes
+      include Interactor
+
+      delegate :topic, :new_index, to: :context
+
+      def call
+        return if invalid_index
+
+        update_indexes
+      end
+
+      private
+
+      def update_indexes
+        if new_index > old_index
+          decrement_indexes_of_next_topics
+        else
+          increment_indexes_of_previous_topics
+        end
+
+        topic.update(order_index: new_index)
+      end
+
+      def decrement_indexes_of_next_topics
+        course_topics[old_index + 1..new_index].each { |t| t.decrement!(:order_index) }
+      end
+
+      def increment_indexes_of_previous_topics
+        course_topics[new_index..old_index - 1].each { |t| t.increment!(:order_index) }
+      end
+
+      def course_topics
+        @course_topics ||= Topic.where(course: topic.course).ordered_by_index
+      end
+
+      def invalid_index
+        new_index == old_index || course_topics[new_index].nil?
+      end
+
+      def old_index
+        topic.order_index
+      end
+    end
+  end
+end

--- a/app/javascript/packs/components/SortableTopicsComponent.jsx
+++ b/app/javascript/packs/components/SortableTopicsComponent.jsx
@@ -12,16 +12,16 @@ class SortableTopicsComponent extends React.Component {
       topics: arrayMove(this.state.topics, oldIndex, newIndex),
     });
 
-    this.state.topics.forEach((topic, order_index) => {
-      $.ajax({
-        url: "/api/v1/topics/" + topic.id,
-        method: "PUT",
-        data: {
-          topic: {
-            order_index: order_index
-          }
+    var topicId = this.state.topics[newIndex].id
+
+    $.ajax({
+      url: "/api/v1/topics/" + topicId,
+      method: "PUT",
+      data: {
+        topic: {
+          order_index: newIndex
         }
-      });
+      }
     });
   };
 
@@ -63,4 +63,3 @@ const CourseTopic = SortableElement(({topic}) => {
     </div>
   )
 })
-

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,4 +1,7 @@
 FactoryGirl.define do
   factory :topic do
+    course
+    title { FFaker::Lorem.sentence(3) }
+    slug { FFaker::Internet.slug(FFaker::Lorem.sentence(3), "-")}
   end
 end

--- a/spec/interactors/teachers/topics/update_order_indexes.rb
+++ b/spec/interactors/teachers/topics/update_order_indexes.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe Teachers::Topics::UpdateOrderIndexes do
+  let(:course) { create :course }
+
+  before do
+    0.upto(4) { |i| create :topic, course: course, order_index: i }
+  end
+
+  describe "#call" do
+    subject(:interactor_call) { described_class.call(topic: topic, new_index: 1) }
+
+    let!(:topic) { Topic.first }
+
+    it "changes order indexes of corresponding topics correctly" do
+      expect(interactor_call).to be_success
+      expect(Topic.order(:id).pluck(:order_index)).to eq([1, 0, 2, 3, 4])
+    end
+  end
+end


### PR DESCRIPTION
Fixed ineffective way of making request to update order index of each topic in course, so it make only one request instead of N.